### PR TITLE
Release 1.4.6 xslt3 streaming test

### DIFF
--- a/src/main/resources/xslt/3.0-streamable/compile-for-svrl.xsl
+++ b/src/main/resources/xslt/3.0-streamable/compile-for-svrl.xsl
@@ -107,7 +107,7 @@
   <xsl:template name="schxslt-api:validation-stylesheet-body-top-hook">
     <xsl:param name="schema" as="element(sch:schema)" required="yes"/>
     <import href="{resolve-uri('streaming-utilities/position-accumulator.xsl', static-base-uri())}"/>
-    <mode use-accumulators="position"/>
+    <mode use-accumulators="#all"/>
   </xsl:template>
 
   <xsl:template name="schxslt-api:validation-stylesheet-body-bottom-hook">

--- a/src/main/resources/xslt/3.0-streamable/compile-for-svrl.xsl
+++ b/src/main/resources/xslt/3.0-streamable/compile-for-svrl.xsl
@@ -1,4 +1,4 @@
-<xsl:transform version="2.0"
+<xsl:transform version="3.0"
                xmlns="http://www.w3.org/1999/XSL/TransformAlias"
                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
                xmlns:error="https://doi.org/10.5281/zenodo.1495494#error"
@@ -6,11 +6,10 @@
                xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"
                xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
                xmlns:xs="http://www.w3.org/2001/XMLSchema"
-               xmlns:mf="http://example.com/mf"
+               xmlns:str="https://hiltonroscoe.com/ns/streamatron/v1"
                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
   <xsl:import href="streaming-utilities/position-accumulator.xsl"/>
-
   <xsl:import href="compile/compile-3.0.xsl"/>
 
   <xsl:template name="schxslt-api:report">
@@ -185,7 +184,7 @@
 
   <xsl:function name="schxslt:location" as="xs:string" visibility="public" streamability="inspection">
     <xsl:param name="node" as="node()"/>
-    <xsl:sequence select="$node => mf:path()"/>
+    <xsl:sequence select="$node => str:path()"/>
   </xsl:function>
 
   <xsl:function name="schxslt:is-location-function" as="xs:boolean">

--- a/src/main/resources/xslt/3.0-streamable/compile/compile-3.0.xsl
+++ b/src/main/resources/xslt/3.0-streamable/compile/compile-3.0.xsl
@@ -162,9 +162,9 @@
     <xsl:call-template name="schxslt:check-multiply-defined">
       <xsl:with-param name="bindings" select="sch:let" as="element(sch:let)*"/>
     </xsl:call-template>
-
+    <xsl:variable name="groundedMode" select="$mode || '-grounded' || generate-id(.)"/>
     <xsl:apply-templates select="." mode="create-template-mode-switch">
-      <xsl:with-param name="mode" select="$mode || '-grounded'"/>      
+      <xsl:with-param name="mode" select="$groundedMode"/>      
     </xsl:apply-templates>
     
       <template match="{@context}" priority="{count(following::sch:rule)}" mode="{$mode}">
@@ -178,7 +178,7 @@
         <choose>
           <when test="not($schxslt:isBursting)">
             <variable name="burstData" select="{@str:streaming}()" />          
-            <apply-templates select="$burstData" mode="{$mode}-grounded">          
+            <apply-templates select="$burstData" mode="{$groundedMode}">          
               <with-param name="schxslt:rules" select="$schxslt:rules"/>
               <with-param name="schxslt:streamed-context" select="'{{generate-id()}}'"/>
             </apply-templates>

--- a/src/main/resources/xslt/3.0-streamable/compile/compile-3.0.xsl
+++ b/src/main/resources/xslt/3.0-streamable/compile/compile-3.0.xsl
@@ -3,7 +3,8 @@
   xmlns:sch="http://purl.oclc.org/dsdl/schematron"
   xmlns:error="https://doi.org/10.5281/zenodo.1495494#error"
   xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"
-  xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
   <xsl:import href="api-3.0.xsl"/>

--- a/src/main/resources/xslt/3.0-streamable/compile/compile-3.0.xsl
+++ b/src/main/resources/xslt/3.0-streamable/compile/compile-3.0.xsl
@@ -1,12 +1,10 @@
 <!-- Compile preprocessed Schematron to validation stylesheet -->
-<xsl:transform version="2.0"
-               xmlns="http://www.w3.org/1999/XSL/TransformAlias"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:error="https://doi.org/10.5281/zenodo.1495494#error"
-               xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"
-               xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"
-               xmlns:xs="http://www.w3.org/2001/XMLSchema"
-               xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:transform version="2.0" xmlns="http://www.w3.org/1999/XSL/TransformAlias"
+  xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+  xmlns:error="https://doi.org/10.5281/zenodo.1495494#error"
+  xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"
+  xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
   <xsl:import href="api-3.0.xsl"/>
 
@@ -34,10 +32,10 @@
 
   <xsl:template name="schxslt:compile">
     <xsl:param name="schematron" as="element(sch:schema)" required="yes"/>
-
-    <xsl:variable name="effective-phase" select="schxslt:effective-phase($schematron, $phase)" as="xs:string"/>
-    <xsl:variable name="active-patterns" select="schxslt:active-patterns($schematron, $effective-phase)" as="element(sch:pattern)+"/>
-
+    <xsl:variable name="effective-phase" select="schxslt:effective-phase($schematron, $phase)"
+      as="xs:string"/>
+    <xsl:variable name="active-patterns"
+      select="schxslt:active-patterns($schematron, $effective-phase)" as="element(sch:pattern)+"/>
     <xsl:variable name="validation-stylesheet-body">
       <xsl:call-template name="schxslt:validation-stylesheet-body">
         <xsl:with-param name="patterns" as="element(sch:pattern)+" select="$active-patterns"/>
@@ -45,6 +43,7 @@
     </xsl:variable>
 
     <transform version="{schxslt:xslt-version($schematron)}">
+
       <xsl:for-each select="$schematron/sch:ns">
         <xsl:namespace name="{@prefix}" select="@uri"/>
       </xsl:for-each>
@@ -57,21 +56,24 @@
       </xsl:call-template>
 
       <output indent="yes"/>
-      
+      <import-schema namespace="http://itl.nist.gov/ns/voting/1500-103/v1"
+        schema-location="NIST_V0_cast_vote_records.xsd"/>
       <mode streamable="yes" use-accumulators="position"/>
-      
+
       <xsl:for-each select="$schematron//sch:reference">
         <accumulator name="{@context}" as="node()?" initial-value="()" streamable="yes">
-          <accumulator-rule match="{@context}" select="." phase="end" saxon:capture="yes" xmlns:saxon="http://saxon.sf.net/"/>       
+          <accumulator-rule match="{@context}" select="." phase="end" saxon:capture="yes"
+            xmlns:saxon="http://saxon.sf.net/"/>
         </accumulator>
       </xsl:for-each>
-        
-      
+
+
       <xsl:sequence select="$schematron/xsl:key[not(preceding-sibling::sch:pattern)]"/>
       <xsl:sequence select="$schematron/xsl:function[not(preceding-sibling::sch:pattern)]"/>
 
       <!-- See https://github.com/dmj/schxslt/issues/25 -->
-      <xsl:variable name="global-bindings" as="element(sch:let)*" select="($schematron/sch:let, $schematron/sch:phase[@id eq $effective-phase]/sch:let, $active-patterns/sch:let)"/>
+      <xsl:variable name="global-bindings" as="element(sch:let)*"
+        select="($schematron/sch:let, $schematron/sch:phase[@id eq $effective-phase]/sch:let, $active-patterns/sch:let)"/>
       <xsl:call-template name="schxslt:check-multiply-defined">
         <xsl:with-param name="bindings" select="$global-bindings" as="element(sch:let)*"/>
       </xsl:call-template>
@@ -81,24 +83,28 @@
       </xsl:call-template>
 
       <xsl:call-template name="schxslt:let-variable">
-        <xsl:with-param name="bindings" select="($schematron/sch:phase[@id eq $effective-phase]/sch:let, $active-patterns/sch:let)"/>
+        <xsl:with-param name="bindings"
+          select="($schematron/sch:phase[@id eq $effective-phase]/sch:let, $active-patterns/sch:let)"
+        />
       </xsl:call-template>
 
       <template match="/">
         <xsl:sequence select="$schematron/sch:phase[@id eq $effective-phase]/@xml:base"/>
 
         <xsl:call-template name="schxslt:let-variable">
-          <xsl:with-param name="bindings" select="$schematron/sch:phase[@id eq $effective-phase]/sch:let"/>
+          <xsl:with-param name="bindings"
+            select="$schematron/sch:phase[@id eq $effective-phase]/sch:let"/>
         </xsl:call-template>
 
         <variable name="report" as="element(schxslt:report)">
           <schxslt:report>
             <fork>
-              <xsl:for-each select="$validation-stylesheet-body/xsl:mode[@name[not(ends-with(., '-entry'))]]">
+              <xsl:for-each
+                select="$validation-stylesheet-body/xsl:mode[@name[not(ends-with(., '-entry'))]]">
                 <sequence>
                   <apply-templates select="." mode="{@name}-entry"/>
                 </sequence>
-              </xsl:for-each>              
+              </xsl:for-each>
             </fork>
           </schxslt:report>
         </variable>
@@ -119,7 +125,7 @@
       </template>
 
       <template match="text() | @*" mode="#all" priority="-10"/>
-      
+
       <template match="*" mode="#all" priority="-10">
         <apply-templates mode="#current" select="@*"/>
         <apply-templates mode="#current"/>
@@ -141,13 +147,30 @@
     </desc>
     <param name="mode">Template mode</param>
   </doc>
-  <xsl:template match="sch:rule[not(@burst)]">
+  <!-- handles no streaming rules (default) TODO FIX IT -->
+  <xsl:template match="sch:rule[not(@burst) or @burst = 'off']">
     <xsl:param name="mode" as="xs:string" required="yes"/>
 
     <xsl:apply-templates select="." mode="create-template-mode">
       <xsl:with-param name="mode" select="$mode"/>
     </xsl:apply-templates>
-    
+
+    <xsl:apply-templates select="." mode="create-template-mode">
+      <xsl:with-param name="mode" select="$mode || '-grounded'"/>
+    </xsl:apply-templates>
+
+    <xsl:call-template name="schxslt:check-multiply-defined">
+      <xsl:with-param name="bindings" select="sch:let" as="element(sch:let)*"/>
+    </xsl:call-template>
+  </xsl:template>
+  <!-- handles basic streaming -->
+  <xsl:template match="sch:rule[@burst = 'on']">
+    <xsl:param name="mode" as="xs:string" required="yes"/>
+
+    <xsl:apply-templates select="." mode="create-template-mode">
+      <xsl:with-param name="mode" select="$mode"/>
+    </xsl:apply-templates>
+
     <xsl:apply-templates select="." mode="create-template-mode">
       <xsl:with-param name="mode" select="$mode || '-grounded'"/>
     </xsl:apply-templates>
@@ -157,34 +180,36 @@
     </xsl:call-template>
 
   </xsl:template>
-
-  <xsl:template match="sch:rule[@burst]">
+  <!-- handles bursting -->
+  <xsl:template match="sch:rule[@burst = ('copy-of','snapshot','inherit')]">
     <xsl:param name="mode" as="xs:string" required="yes"/>
-    
+
     <xsl:call-template name="schxslt:check-multiply-defined">
       <xsl:with-param name="bindings" select="sch:let" as="element(sch:let)*"/>
     </xsl:call-template>
-    
+
     <xsl:apply-templates select="." mode="create-template-mode-switch">
       <xsl:with-param name="mode" select="$mode || '-grounded'"/>
+      <xsl:with-param name="isInherited" select="@burst = 'inherit'" />
     </xsl:apply-templates>
-    
-    <template match="{@context}" priority="{count(following::sch:rule)}" mode="{$mode}">
-      <xsl:sequence select="(@xml:base, ../@xml:base)"/>
+    <xsl:if test="@burst != 'inherit'">
+      <template match="{@context}" priority="{count(following::sch:rule)}" mode="{$mode}">
+        <xsl:sequence select="(@xml:base, ../@xml:base)"/>
 
-      <!-- Check if a context node was already matched by a rule of the current pattern. -->
-      <param name="schxslt:rules" as="element(schxslt:rule)*"/>
-      
-      <!--<xsl:call-template name="schxslt:let-variable">
-        <xsl:with-param name="bindings" as="element(sch:let)*" select="sch:let"/>
-      </xsl:call-template>-->
+        <!-- Check if a context node was already matched by a rule of the current pattern. -->
+        <param name="schxslt:rules" as="element(schxslt:rule)*"/>
 
-      <apply-templates select="{@burst}()" mode="{$mode}-grounded">
-        <with-param name="schxslt:rules" select="$schxslt:rules"/>
-        <with-param name="schxslt:streamed-context" select="'{{generate-id()}}'"/>
-      </apply-templates>
-    </template>
+        <!--<xsl:call-template name="schxslt:let-variable">
+          <xsl:with-param name="bindings" as="element(sch:let)*" select="sch:let"/>
+        </xsl:call-template>-->
 
+        <apply-templates select="{@burst}()" mode="{$mode}-grounded">
+          <with-param name="schxslt:isBursting" tunnel="yes" select="true()"/>
+          <with-param name="schxslt:rules" select="$schxslt:rules"/>
+          <with-param name="schxslt:streamed-context" select="'{{generate-id()}}'"/>
+        </apply-templates>
+      </template>
+    </xsl:if>
   </xsl:template>
 
   <xsl:template match="sch:rule" mode="create-template-mode">
@@ -205,7 +230,8 @@
       </xsl:call-template>
 
       <choose>
-        <when test="empty($schxslt:rules[@pattern = '{generate-id(..)}'][@context = generate-id(current())])">
+        <when
+          test="empty($schxslt:rules[@pattern = '{generate-id(..)}'][@context = generate-id(current())])">
           <schxslt:rule pattern="{generate-id(..)}@{{base-uri(.)}}">
             <xsl:call-template name="schxslt-api:fired-rule">
               <xsl:with-param name="rule" as="element(sch:rule)" select="."/>
@@ -231,32 +257,40 @@
     </template>
 
   </xsl:template>
-  
- <xsl:template match="sch:rule" mode="create-template-mode-switch">
-    <xsl:param name="mode" as="xs:string" required="yes"/>
 
+  <xsl:template match="sch:rule" mode="create-template-mode-switch">
+    <xsl:param name="mode" as="xs:string" required="yes"/>
+    <xsl:param name="isInherited" />
+        
     <xsl:call-template name="schxslt:check-multiply-defined">
       <xsl:with-param name="bindings" select="sch:let" as="element(sch:let)*"/>
     </xsl:call-template>
 
     <template match="{@context}" priority="{count(following::sch:rule)}" mode="{$mode}">
+      <param name="schxslt:isBursting" tunnel="yes" as="xs:boolean" />
       <xsl:sequence select="(@xml:base, ../@xml:base)"/>
 
       <!-- Check if a context node was already matched by a rule of the current pattern. -->
       <param name="schxslt:rules" as="element(schxslt:rule)*"/>
       <param name="schxslt:streamed-context"/>
-      
-      <!-- JND add in variable, note select is not contextual -->
+
+      <!-- if rule is inherited, it must be called from a bursting context -->
+      <xsl:if test="$isInherited">
+        <if test="$schxslt:isBursting">          
+          <message terminate="yes">Inherited rule is not bursting.</message> 
+        </if>
+      </xsl:if>
       <xsl:for-each select="//sch:reference">
-        <variable name="{@name}" select="accumulator-after('{@context}')" />
+        <variable name="{@name}" select="accumulator-after('{@context}')"/>
       </xsl:for-each>
-      
+
       <xsl:call-template name="schxslt:let-variable">
         <xsl:with-param name="bindings" as="element(sch:let)*" select="sch:let"/>
       </xsl:call-template>
 
       <choose>
-        <when test="empty($schxslt:rules[@pattern = '{generate-id(..)}'][@context = $schxslt:streamed-context])">
+        <when
+          test="empty($schxslt:rules[@pattern = '{generate-id(..)}'][@context = $schxslt:streamed-context])">
           <schxslt:rule pattern="{generate-id(..)}@{{base-uri(.)}}">
             <xsl:call-template name="schxslt-api:fired-rule">
               <xsl:with-param name="rule" as="element(sch:rule)" select="."/>
@@ -282,7 +316,7 @@
     </template>
 
   </xsl:template>
-  
+
   <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl">
     <desc>
       <p>Return body of validation stylesheet</p>

--- a/src/main/resources/xslt/3.0-streamable/compile/compile-3.0.xsl
+++ b/src/main/resources/xslt/3.0-streamable/compile/compile-3.0.xsl
@@ -60,6 +60,13 @@
       
       <mode streamable="yes" use-accumulators="position"/>
       
+      <xsl:for-each select="$schematron//sch:reference">
+        <accumulator name="{@context}" as="node()?" initial-value="()" streamable="yes">
+          <accumulator-rule match="{@context}" select="." phase="end" saxon:capture="yes" xmlns:saxon="http://saxon.sf.net/"/>       
+        </accumulator>
+      </xsl:for-each>
+        
+      
       <xsl:sequence select="$schematron/xsl:key[not(preceding-sibling::sch:pattern)]"/>
       <xsl:sequence select="$schematron/xsl:function[not(preceding-sibling::sch:pattern)]"/>
 
@@ -167,10 +174,10 @@
 
       <!-- Check if a context node was already matched by a rule of the current pattern. -->
       <param name="schxslt:rules" as="element(schxslt:rule)*"/>
-
-      <xsl:call-template name="schxslt:let-variable">
+      
+      <!--<xsl:call-template name="schxslt:let-variable">
         <xsl:with-param name="bindings" as="element(sch:let)*" select="sch:let"/>
-      </xsl:call-template>
+      </xsl:call-template>-->
 
       <apply-templates select="{@burst}()" mode="{$mode}-grounded">
         <with-param name="schxslt:rules" select="$schxslt:rules"/>
@@ -238,7 +245,12 @@
       <!-- Check if a context node was already matched by a rule of the current pattern. -->
       <param name="schxslt:rules" as="element(schxslt:rule)*"/>
       <param name="schxslt:streamed-context"/>
-
+      
+      <!-- JND add in variable, note select is not contextual -->
+      <xsl:for-each select="//sch:reference">
+        <variable name="{@name}" select="accumulator-after('{@context}')" />
+      </xsl:for-each>
+      
       <xsl:call-template name="schxslt:let-variable">
         <xsl:with-param name="bindings" as="element(sch:let)*" select="sch:let"/>
       </xsl:call-template>

--- a/src/main/resources/xslt/3.0-streamable/compile/compile-3.0.xsl
+++ b/src/main/resources/xslt/3.0-streamable/compile/compile-3.0.xsl
@@ -148,7 +148,7 @@
     <param name="mode">Template mode</param>
   </doc>
   <!-- handles no streaming rules (default) TODO FIX IT -->
-  <xsl:template match="sch:rule[not(@burst) or @burst = 'off']">
+  <xsl:template match="sch:rule[not(@burst) or @burst = ('off','inherit')]">
     <xsl:param name="mode" as="xs:string" required="yes"/>
  
     <xsl:apply-templates select="." mode="create-template-mode">
@@ -173,7 +173,7 @@
 
   </xsl:template>
   <!-- handles bursting -->
-  <xsl:template match="sch:rule[@burst = ('copy-of','snapshot','inherit')]">
+  <xsl:template match="sch:rule[@burst = ('copy-of','snapshot')]">
     <xsl:param name="mode" as="xs:string" required="yes"/>
 
     <xsl:call-template name="schxslt:check-multiply-defined">

--- a/src/main/resources/xslt/3.0-streamable/compile/compile-3.0.xsl
+++ b/src/main/resources/xslt/3.0-streamable/compile/compile-3.0.xsl
@@ -58,7 +58,7 @@
       <output indent="yes"/>
       <import-schema namespace="http://itl.nist.gov/ns/voting/1500-103/v1"
         schema-location="NIST_V0_cast_vote_records.xsd"/>
-      <mode streamable="yes" use-accumulators="position"/>
+      <mode streamable="yes" use-accumulators="#all"/>
 
       <xsl:for-each select="$schematron//sch:reference">
         <accumulator name="{@context}" as="node()?" initial-value="()" streamable="yes">
@@ -148,7 +148,7 @@
     <param name="mode">Template mode</param>
   </doc>
   <!-- handles no streaming rules (default) TODO FIX IT -->
-  <xsl:template match="sch:rule[not(@burst) or @burst = ('off','inherit')]">
+  <xsl:template match="sch:rule[not(@streaming) or @streaming = ('off','inherit')]">
     <xsl:param name="mode" as="xs:string" required="yes"/>
  
     <xsl:apply-templates select="." mode="create-template-mode">
@@ -160,7 +160,7 @@
     </xsl:call-template>
   </xsl:template>
   <!-- handles basic streaming -->
-  <xsl:template match="sch:rule[@burst = 'on']">
+  <xsl:template match="sch:rule[@streaming = 'on']">
     <xsl:param name="mode" as="xs:string" required="yes"/>
 
     <xsl:apply-templates select="." mode="create-template-mode">
@@ -173,7 +173,7 @@
 
   </xsl:template>
   <!-- handles bursting -->
-  <xsl:template match="sch:rule[@burst = ('copy-of','snapshot')]">
+  <xsl:template match="sch:rule[@streaming = ('copy-of','snapshot')]">
     <xsl:param name="mode" as="xs:string" required="yes"/>
 
     <xsl:call-template name="schxslt:check-multiply-defined">
@@ -197,7 +197,7 @@
         </xsl:call-template>-->
         <choose>
           <when test="not($schxslt:isBursting)">
-            <variable name="burstData" select="{@burst}()" />          
+            <variable name="burstData" select="{@streaming}()" />          
             <apply-templates select="$burstData" mode="{$mode}-grounded">          
               <with-param name="schxslt:rules" select="$schxslt:rules"/>
               <with-param name="schxslt:streamed-context" select="'{{generate-id()}}'"/>
@@ -214,7 +214,7 @@
           </otherwise>
         </choose>
       </template>
-      <!-- TODO need rule for when @burst matches illegal value -->
+      <!-- TODO need rule for when @streaming matches illegal value -->
     
   </xsl:template>
 
@@ -231,9 +231,13 @@
       <!-- Check if a context node was already matched by a rule of the current pattern. -->
       <param name="schxslt:rules" as="element(schxslt:rule)*"/>
 
+      <xsl:for-each select="//sch:reference">
+        <variable name="{@name}" select="accumulator-after('{@context}')"/>
+      </xsl:for-each>
+
       <xsl:call-template name="schxslt:let-variable">
         <xsl:with-param name="bindings" as="element(sch:let)*" select="sch:let"/>
-      </xsl:call-template>
+      </xsl:call-template>      
 
       <choose>
         <when
@@ -329,8 +333,8 @@
       <xsl:variable name="mode" as="xs:string" select="generate-id()"/>
       <xsl:variable name="baseUri" as="xs:anyURI" select="base-uri(.)"/>
 
-      <mode name="{$mode}" streamable="yes" use-accumulators="position"/>
-      <mode name="{$mode}-entry" streamable="yes" use-accumulators="position"/>
+      <mode name="{$mode}" streamable="yes" use-accumulators="#all"/>
+      <mode name="{$mode}-entry" streamable="yes" use-accumulators="#all"/>
 
       <template match="/" mode="{$mode}-entry">
         <xsl:sequence select="@xml:base"/>

--- a/src/main/resources/xslt/3.0-streamable/compile/compile-3.0.xsl
+++ b/src/main/resources/xslt/3.0-streamable/compile/compile-3.0.xsl
@@ -142,29 +142,16 @@
     <param name="mode">Template mode</param>
   </doc>
   <!-- handles no streaming rules (default) TODO FIX IT -->
-  <xsl:template match="sch:rule[not(@streaming) or @streaming = ('off','inherit')]">
+  <xsl:template match="sch:rule[not(@streaming) or @streaming = ('on','off','inherit')]">
     <xsl:param name="mode" as="xs:string" required="yes"/>
- 
+    <xsl:variable name="modeExtension" select="if(@streaming='on') then '' else '-grounded'" />
     <xsl:apply-templates select="." mode="create-template-mode">
-      <xsl:with-param name="mode" select="$mode || '-grounded'"/>
+      <xsl:with-param name="mode" select="$mode || $modeExtension"/>
     </xsl:apply-templates>
 
     <xsl:call-template name="schxslt:check-multiply-defined">
       <xsl:with-param name="bindings" select="sch:let" as="element(sch:let)*"/>
     </xsl:call-template>
-  </xsl:template>
-  <!-- handles basic streaming -->
-  <xsl:template match="sch:rule[@streaming = 'on']">
-    <xsl:param name="mode" as="xs:string" required="yes"/>
-
-    <xsl:apply-templates select="." mode="create-template-mode">
-      <xsl:with-param name="mode" select="$mode"/>
-    </xsl:apply-templates>    
-
-    <xsl:call-template name="schxslt:check-multiply-defined">
-      <xsl:with-param name="bindings" select="sch:let" as="element(sch:let)*"/>
-    </xsl:call-template>
-
   </xsl:template>
   <!-- handles bursting -->
   <xsl:template match="sch:rule[@streaming = ('copy-of','snapshot')]">
@@ -186,9 +173,6 @@
         <!-- Check if a context node was already matched by a rule of the current pattern. -->
         <param name="schxslt:rules" as="element(schxslt:rule)*"/>
 
-        <!--<xsl:call-template name="schxslt:let-variable">
-          <xsl:with-param name="bindings" as="element(sch:let)*" select="sch:let"/>
-        </xsl:call-template>-->
         <choose>
           <when test="not($schxslt:isBursting)">
             <variable name="burstData" select="{@streaming}()" />          
@@ -207,8 +191,7 @@
             <apply-templates mode="#current" />
           </otherwise>
         </choose>
-      </template>
-      <!-- TODO need rule for when @streaming matches illegal value -->
+      </template>      
     
   </xsl:template>
 

--- a/src/main/resources/xslt/3.0-streamable/compile/compile-3.0.xsl
+++ b/src/main/resources/xslt/3.0-streamable/compile/compile-3.0.xsl
@@ -165,11 +165,7 @@
 
     <xsl:apply-templates select="." mode="create-template-mode">
       <xsl:with-param name="mode" select="$mode"/>
-    </xsl:apply-templates>
-
-    <xsl:apply-templates select="." mode="create-template-mode">
-      <xsl:with-param name="mode" select="$mode || '-grounded'"/>
-    </xsl:apply-templates>
+    </xsl:apply-templates>    
 
     <xsl:call-template name="schxslt:check-multiply-defined">
       <xsl:with-param name="bindings" select="sch:let" as="element(sch:let)*"/>

--- a/src/main/resources/xslt/3.0-streamable/compile/compile-3.0.xsl
+++ b/src/main/resources/xslt/3.0-streamable/compile/compile-3.0.xsl
@@ -61,7 +61,7 @@
       <mode streamable="yes" use-accumulators="#all"/>
 
       <xsl:for-each select="$schematron//sch:reference">
-        <accumulator name="{@context}" as="node()?" initial-value="()" streamable="yes">
+        <accumulator name="{@name}" as="node()?" initial-value="()" streamable="yes">
           <accumulator-rule match="{@context}" select="." phase="end" saxon:capture="yes"
             xmlns:saxon="http://saxon.sf.net/"/>
         </accumulator>
@@ -232,7 +232,7 @@
       <param name="schxslt:rules" as="element(schxslt:rule)*"/>
 
       <xsl:for-each select="//sch:reference">
-        <variable name="{@name}" select="accumulator-after('{@context}')"/>
+        <variable name="{@name}" select="accumulator-after('{@name}')"/>
       </xsl:for-each>
 
       <xsl:call-template name="schxslt:let-variable">
@@ -284,7 +284,7 @@
       <param name="schxslt:streamed-context"/>
       
       <xsl:for-each select="//sch:reference">
-        <variable name="{@name}" select="accumulator-after('{@context}')"/>
+        <variable name="{@name}" select="accumulator-after('{@name}')"/>
       </xsl:for-each>
 
       <xsl:call-template name="schxslt:let-variable">

--- a/src/main/resources/xslt/3.0-streamable/compile/compile-3.0.xsl
+++ b/src/main/resources/xslt/3.0-streamable/compile/compile-3.0.xsl
@@ -150,11 +150,7 @@
   <!-- handles no streaming rules (default) TODO FIX IT -->
   <xsl:template match="sch:rule[not(@burst) or @burst = 'off']">
     <xsl:param name="mode" as="xs:string" required="yes"/>
-
-    <xsl:apply-templates select="." mode="create-template-mode">
-      <xsl:with-param name="mode" select="$mode"/>
-    </xsl:apply-templates>
-
+ 
     <xsl:apply-templates select="." mode="create-template-mode">
       <xsl:with-param name="mode" select="$mode || '-grounded'"/>
     </xsl:apply-templates>
@@ -209,6 +205,7 @@
           <with-param name="schxslt:streamed-context" select="'{{generate-id()}}'"/>
         </apply-templates>
       </template>
+      <!-- TODO need rule for when @burst matches illegal value -->
     </xsl:if>
   </xsl:template>
 
@@ -276,7 +273,7 @@
 
       <!-- if rule is inherited, it must be called from a bursting context -->
       <xsl:if test="$isInherited">
-        <if test="$schxslt:isBursting">          
+        <if test="not($schxslt:isBursting)">          
           <message terminate="yes">Inherited rule is not bursting.</message> 
         </if>
       </xsl:if>
@@ -363,7 +360,13 @@
           </xsl:for-each>
 
           <apply-templates mode="{$mode}" select="."/>
+          
         </for-each>
+        <!-- I don't understand the doc stuff, so putting this here for now -->
+        <!-- move somewhere else so order of fired-rules makes more sense? -->
+        <xsl:for-each select="//sch:reference[@apply-rules='yes']">
+          <apply-templates select="accumulator-after('{@name}')" mode="{$mode}-grounded" />
+        </xsl:for-each>
 
       </template>
 

--- a/src/main/resources/xslt/3.0-streamable/compile/compile-3.0.xsl
+++ b/src/main/resources/xslt/3.0-streamable/compile/compile-3.0.xsl
@@ -32,10 +32,10 @@
 
   <xsl:template name="schxslt:compile">
     <xsl:param name="schematron" as="element(sch:schema)" required="yes"/>
-    <xsl:variable name="effective-phase" select="schxslt:effective-phase($schematron, $phase)"
-      as="xs:string"/>
-    <xsl:variable name="active-patterns"
-      select="schxslt:active-patterns($schematron, $effective-phase)" as="element(sch:pattern)+"/>
+
+    <xsl:variable name="effective-phase" select="schxslt:effective-phase($schematron, $phase)" as="xs:string"/>
+    <xsl:variable name="active-patterns" select="schxslt:active-patterns($schematron, $effective-phase)" as="element(sch:pattern)+"/>
+
     <xsl:variable name="validation-stylesheet-body">
       <xsl:call-template name="schxslt:validation-stylesheet-body">
         <xsl:with-param name="patterns" as="element(sch:pattern)+" select="$active-patterns"/>
@@ -43,7 +43,6 @@
     </xsl:variable>
 
     <transform version="{schxslt:xslt-version($schematron)}">
-
       <xsl:for-each select="$schematron/sch:ns">
         <xsl:namespace name="{@prefix}" select="@uri"/>
       </xsl:for-each>
@@ -72,8 +71,7 @@
       <xsl:sequence select="$schematron/xsl:function[not(preceding-sibling::sch:pattern)]"/>
 
       <!-- See https://github.com/dmj/schxslt/issues/25 -->
-      <xsl:variable name="global-bindings" as="element(sch:let)*"
-        select="($schematron/sch:let, $schematron/sch:phase[@id eq $effective-phase]/sch:let, $active-patterns/sch:let)"/>
+      <xsl:variable name="global-bindings" as="element(sch:let)*" select="($schematron/sch:let, $schematron/sch:phase[@id eq $effective-phase]/sch:let, $active-patterns/sch:let)"/>
       <xsl:call-template name="schxslt:check-multiply-defined">
         <xsl:with-param name="bindings" select="$global-bindings" as="element(sch:let)*"/>
       </xsl:call-template>
@@ -83,17 +81,14 @@
       </xsl:call-template>
 
       <xsl:call-template name="schxslt:let-variable">
-        <xsl:with-param name="bindings"
-          select="($schematron/sch:phase[@id eq $effective-phase]/sch:let, $active-patterns/sch:let)"
-        />
+        <xsl:with-param name="bindings" select="($schematron/sch:phase[@id eq $effective-phase]/sch:let, $active-patterns/sch:let)"/>
       </xsl:call-template>
 
       <template match="/">
         <xsl:sequence select="$schematron/sch:phase[@id eq $effective-phase]/@xml:base"/>
 
         <xsl:call-template name="schxslt:let-variable">
-          <xsl:with-param name="bindings"
-            select="$schematron/sch:phase[@id eq $effective-phase]/sch:let"/>
+          <xsl:with-param name="bindings" select="$schematron/sch:phase[@id eq $effective-phase]/sch:let"/>
         </xsl:call-template>
 
         <variable name="report" as="element(schxslt:report)">
@@ -125,7 +120,6 @@
       </template>
 
       <template match="text() | @*" mode="#all" priority="-10"/>
-
       <template match="*" mode="#all" priority="-10">
         <apply-templates mode="#current" select="@*"/>
         <apply-templates mode="#current"/>
@@ -275,8 +269,7 @@
       <xsl:with-param name="bindings" select="sch:let" as="element(sch:let)*"/>
     </xsl:call-template>
 
-    <template match="{@context}" priority="{count(following::sch:rule)}" mode="{$mode}">
-      
+    <template match="{@context}" priority="{count(following::sch:rule)}" mode="{$mode}">      
       <xsl:sequence select="(@xml:base, ../@xml:base)"/>
 
       <!-- Check if a context node was already matched by a rule of the current pattern. -->
@@ -292,8 +285,7 @@
       </xsl:call-template>
 
       <choose>
-        <when
-          test="empty($schxslt:rules[@pattern = '{generate-id(..)}'][@context = $schxslt:streamed-context])">
+        <when test="empty($schxslt:rules[@pattern = '{generate-id(..)}'][@context = $schxslt:streamed-context])">
           <schxslt:rule pattern="{generate-id(..)}@{{base-uri(.)}}">
             <xsl:call-template name="schxslt-api:fired-rule">
               <xsl:with-param name="rule" as="element(sch:rule)" select="."/>
@@ -365,8 +357,7 @@
             </schxslt:pattern>
           </xsl:for-each>
 
-          <apply-templates mode="{$mode}" select="."/>
-          
+          <apply-templates mode="{$mode}" select="."/>        
         </for-each>
         <!-- I don't understand the doc stuff, so putting this here for now -->
         <!-- move somewhere else so order of fired-rules makes more sense? -->

--- a/src/main/resources/xslt/3.0-streamable/compile/compile-3.0.xsl
+++ b/src/main/resources/xslt/3.0-streamable/compile/compile-3.0.xsl
@@ -3,7 +3,8 @@
   xmlns:sch="http://purl.oclc.org/dsdl/schematron"
   xmlns:error="https://doi.org/10.5281/zenodo.1495494#error"
   xmlns:schxslt-api="https://doi.org/10.5281/zenodo.1495494#api"
-  xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494" 
+  xmlns:schxslt="https://doi.org/10.5281/zenodo.1495494"
+  xmlns:str="https://hiltonroscoe.com/ns/streamatron/v1"
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
@@ -60,7 +61,7 @@
         schema-location="NIST_V0_cast_vote_records.xsd"/>
       <mode streamable="yes" use-accumulators="#all"/>
 
-      <xsl:for-each select="$schematron//sch:reference">
+      <xsl:for-each select="$schematron//str:reference">
         <accumulator name="{@name}" as="node()?" initial-value="()" streamable="yes">
           <accumulator-rule match="{@context}" select="." phase="end" saxon:capture="yes"
             xmlns:saxon="http://saxon.sf.net/"/>
@@ -143,9 +144,9 @@
     <param name="mode">Template mode</param>
   </doc>
   <!-- handles no streaming rules (default) TODO FIX IT -->
-  <xsl:template match="sch:rule[not(@streaming) or @streaming = ('on','off','inherit')]">
+  <xsl:template match="sch:rule[not(@str:streaming) or @str:streaming = ('on','off','inherit')]">
     <xsl:param name="mode" as="xs:string" required="yes"/>
-    <xsl:variable name="modeExtension" select="if(@streaming='on') then '' else '-grounded'" />
+    <xsl:variable name="modeExtension" select="if(@str:streaming='on') then '' else '-grounded'" />
     <xsl:apply-templates select="." mode="create-template-mode">
       <xsl:with-param name="mode" select="$mode || $modeExtension"/>
     </xsl:apply-templates>
@@ -155,7 +156,7 @@
     </xsl:call-template>
   </xsl:template>
   <!-- handles bursting -->
-  <xsl:template match="sch:rule[@streaming = ('copy-of','snapshot')]">
+  <xsl:template match="sch:rule[@str:streaming = ('copy-of','snapshot')]">
     <xsl:param name="mode" as="xs:string" required="yes"/>
 
     <xsl:call-template name="schxslt:check-multiply-defined">
@@ -176,7 +177,7 @@
 
         <choose>
           <when test="not($schxslt:isBursting)">
-            <variable name="burstData" select="{@streaming}()" />          
+            <variable name="burstData" select="{@str:streaming}()" />          
             <apply-templates select="$burstData" mode="{$mode}-grounded">          
               <with-param name="schxslt:rules" select="$schxslt:rules"/>
               <with-param name="schxslt:streamed-context" select="'{{generate-id()}}'"/>
@@ -209,7 +210,7 @@
       <!-- Check if a context node was already matched by a rule of the current pattern. -->
       <param name="schxslt:rules" as="element(schxslt:rule)*"/>
 
-      <xsl:for-each select="//sch:reference">
+      <xsl:for-each select="//str:reference">
         <variable name="{@name}" select="accumulator-after('{@name}')"/>
       </xsl:for-each>
 
@@ -260,7 +261,7 @@
       <param name="schxslt:rules" as="element(schxslt:rule)*"/>
       <param name="schxslt:streamed-context"/>
       
-      <xsl:for-each select="//sch:reference">
+      <xsl:for-each select="//str:reference">
         <variable name="{@name}" select="accumulator-after('{@name}')"/>
       </xsl:for-each>
 
@@ -345,7 +346,7 @@
         </for-each>
         <!-- I don't understand the doc stuff, so putting this here for now -->
         <!-- move somewhere else so order of fired-rules makes more sense? -->
-        <xsl:for-each select="//sch:reference[@apply-rules='yes']">
+        <xsl:for-each select="//str:reference[@apply-rules='yes']">
           <apply-templates select="accumulator-after('{@name}')" mode="{$mode}-grounded" />
         </xsl:for-each>
 

--- a/src/main/resources/xslt/3.0-streamable/streaming-utilities/position-accumulator.xsl
+++ b/src/main/resources/xslt/3.0-streamable/streaming-utilities/position-accumulator.xsl
@@ -2,11 +2,11 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xmlns:map="http://www.w3.org/2005/xpath-functions/map"
-    xmlns:mf="http://example.com/mf"
+    xmlns:str="https://hiltonroscoe.com/ns/streamatron/v1"
     exclude-result-prefixes="#all"
     version="3.0">
     
-    <xsl:function name="mf:path" as="xs:string" streamability="inspection" visibility="public">
+    <xsl:function name="str:path" as="xs:string" streamability="inspection" visibility="public">
         <xsl:param name="node" as="node()"/>
         <xsl:sequence
             select="if ($node instance of document-node())
@@ -14,12 +14,12 @@
                     else 
                     $node/ancestor-or-self::node()
                     !(
-                       mf:step(.) || 
-                       mf:positional-predicate(.)
+                       str:step(.) || 
+                       str:positional-predicate(.)
                      ) => string-join('/')"/>
     </xsl:function>
 
-  <xsl:function name="mf:step" as="xs:string?" streamability="inspection" visibility="public">
+  <xsl:function name="str:step" as="xs:string?" streamability="inspection" visibility="public">
     <xsl:param name="node" as="node()"/>
     <xsl:sequence select="if ($node instance of element())
                           then $node!('Q{' || namespace-uri-from-QName(node-name()) || '}' || local-name())
@@ -29,9 +29,9 @@
                                 else $node!('@' || 'Q{' || namespace-uri-from-QName(node-name()) || '}' || local-name())
                                )
                           else if ($node instance of text())
-                          then mf:node-type($node)
+                          then str:node-type($node)
                           else if ($node instance of comment())
-                          then mf:node-type($node)
+                          then str:node-type($node)
                           else if ($node instance of processing-instruction())
                           then 'processing-instruction(' || node-name($node) || ')'
                           else if ($node instance of document-node())
@@ -39,17 +39,17 @@
                           else error(QName('http://example.com/mf', 'type-error'), 'Unknown node type')"/>
   </xsl:function>
 
-  <xsl:function name="mf:positional-predicate" as="xs:string?" streamability="inspection" visibility="public">
+  <xsl:function name="str:positional-predicate" as="xs:string?" streamability="inspection" visibility="public">
     <xsl:param name="node" as="node()"/>
     <xsl:sequence select="if ($node instance of document-node() or $node instance of attribute())
                           then ''
-                          else $node ! ('[' || mf:position(.) || ']')"/>
+                          else $node ! ('[' || str:position(.) || ']')"/>
   </xsl:function>
 
-    <xsl:variable name="mf:empty-child-nodes-map" as="map(xs:string, map(xs:QName, xs:integer)?)"
+    <xsl:variable name="str:empty-child-nodes-map" as="map(xs:string, map(xs:QName, xs:integer)?)"
                 select="map { 'element()' : map {}, 'text()' : map{ QName('', 'text') : 0 }, 'comment()' : map{ QName('', 'comment') : 0 }, 'processing-instruction()' : map{} }"/>
     
-    <xsl:function name="mf:position" as="xs:integer" streamability="inspection" visibility="public">
+    <xsl:function name="str:position" as="xs:integer" streamability="inspection" visibility="public">
         <xsl:param name="node" as="node()"/>
         <xsl:sequence select="if ($node instance of element())
                               then $node!accumulator-before('position')[last() - 1]('element()')(node-name())
@@ -63,15 +63,15 @@
     </xsl:function>
     
     <xsl:accumulator name="position" as="map(xs:string, map(xs:QName, xs:integer))*" initial-value="map{}" streamable="yes">
-        <xsl:accumulator-rule match="document-node()" select="$mf:empty-child-nodes-map"/>
+        <xsl:accumulator-rule match="document-node()" select="$str:empty-child-nodes-map"/>
         <xsl:accumulator-rule match="*"
           select="let $cm := $value[last()],
                       $cem := $cm('element()'),
                       $node-name := node-name()
                   return
                       if (map:contains($cem, $node-name))
-                      then ($value[position() lt last()], map:put($cm, 'element()', map:put($cem, $node-name, $cem($node-name) + 1)), $mf:empty-child-nodes-map)
-                      else ($value[position() lt last()], map:put($cm, 'element()', map:put($cem, $node-name, 1)), $mf:empty-child-nodes-map)"/>
+                      then ($value[position() lt last()], map:put($cm, 'element()', map:put($cem, $node-name, $cem($node-name) + 1)), $str:empty-child-nodes-map)
+                      else ($value[position() lt last()], map:put($cm, 'element()', map:put($cem, $node-name, 1)), $str:empty-child-nodes-map)"/>
         <xsl:accumulator-rule match="text()"
           select="let $cm := $value[last()],
                       $ctm := $cm('text()'),
@@ -100,7 +100,7 @@
           select="$value[position() lt last()]"/>
     </xsl:accumulator>
 
-    <xsl:function name="mf:node-type" as="xs:string" streamability="inspection" visibility="public">
+    <xsl:function name="str:node-type" as="xs:string" streamability="inspection" visibility="public">
       <xsl:param name="node" as="node()"/>
       <xsl:sequence
         select="if ($node instance of document-node())

--- a/src/main/resources/xslt/3.0-streamable/streaming-utilities/test-position-accumulator-against-fn-path.xsl
+++ b/src/main/resources/xslt/3.0-streamable/streaming-utilities/test-position-accumulator-against-fn-path.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xmlns:map="http://www.w3.org/2005/xpath-functions/map"
-    xmlns:mf="http://example.com/mf"
+    xmlns:str="https://hiltonroscoe.com/ns/streamatron/v1"
     exclude-result-prefixes="#all"
     expand-text="yes"
     version="3.0">
@@ -15,7 +15,7 @@
         <xsl:variable name="pos" as="xs:integer">
             <xsl:number/>
         </xsl:variable>
-        <xsl:assert test="path() eq mf:path(.)">{path()} ne {mf:path(.)}</xsl:assert>
+        <xsl:assert test="path() eq str:path(.)">{path()} ne {str:path(.)}</xsl:assert>
         <xsl:next-match/>
     </xsl:template>
     

--- a/src/main/resources/xslt/3.0-streamable/streaming-utilities/test-position-accumulator-against-xsl-number.xsl
+++ b/src/main/resources/xslt/3.0-streamable/streaming-utilities/test-position-accumulator-against-xsl-number.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xmlns:map="http://www.w3.org/2005/xpath-functions/map"
-    xmlns:mf="http://example.com/mf"
+    xmlns:str="https://hiltonroscoe.com/ns/streamatron/v1"
     exclude-result-prefixes="#all"
     expand-text="yes"
     version="3.0">
@@ -15,7 +15,7 @@
         <xsl:variable name="pos" as="xs:integer">
             <xsl:number/>
         </xsl:variable>
-        <xsl:assert test="$pos eq mf:position(.)">{$pos} ne {mf:position(.)} {mf:node-type(.)}</xsl:assert>
+        <xsl:assert test="$pos eq str:position(.)">{$pos} ne {str:position(.)} {str:node-type(.)}</xsl:assert>
         <xsl:next-match/>
     </xsl:template>
     

--- a/src/main/resources/xslt/3.0-streamable/streaming-utilities/test-position-accumulator-all-nodes.xsl
+++ b/src/main/resources/xslt/3.0-streamable/streaming-utilities/test-position-accumulator-all-nodes.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xmlns:map="http://www.w3.org/2005/xpath-functions/map"
-    xmlns:mf="http://example.com/mf"
+    xmlns:str="https://hiltonroscoe.com/ns/streamatron/v1"
     exclude-result-prefixes="#all"
     expand-text="yes"
     version="3.0">
@@ -12,7 +12,7 @@
   <xsl:mode on-no-match="shallow-copy" streamable="yes" use-accumulators="position"/>
 
   <xsl:template match="node()">
-    <xsl:comment>{mf:node-type(.)}: {accumulator-before('position')[last()] => serialize(map { 'method' : 'adaptive' })}</xsl:comment>
+    <xsl:comment>{str:node-type(.)}: {accumulator-before('position')[last()] => serialize(map { 'method' : 'adaptive' })}</xsl:comment>
     <xsl:next-match/>
   </xsl:template>
 

--- a/src/main/resources/xslt/3.0-streamable/streaming-utilities/test-position-accumulator-copy-of.xsl
+++ b/src/main/resources/xslt/3.0-streamable/streaming-utilities/test-position-accumulator-copy-of.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xmlns:map="http://www.w3.org/2005/xpath-functions/map"
-    xmlns:mf="http://example.com/mf"
+    xmlns:str="https://hiltonroscoe.com/ns/streamatron/v1"
     exclude-result-prefixes="#all"
     expand-text="yes"
     version="3.0">
@@ -14,12 +14,12 @@
     <xsl:mode name="non-streamable" on-no-match="shallow-copy" use-accumulators="position"/>
     
     <xsl:template match="*">
-        <xsl:comment>Position: {mf:position(.)}; path: {mf:path(.)}</xsl:comment>
+        <xsl:comment>Position: {str:position(.)}; path: {str:path(.)}</xsl:comment>
         <xsl:apply-templates select="copy-of()" mode="non-streamable"/>
     </xsl:template>
     
     <xsl:template match="*" mode="non-streamable">
-        <xsl:comment>Position: {mf:position(.)}; path: {mf:path(.)}</xsl:comment>
+        <xsl:comment>Position: {str:position(.)}; path: {str:path(.)}</xsl:comment>
         <xsl:next-match/>
     </xsl:template>
     

--- a/src/main/resources/xslt/3.0-streamable/streaming-utilities/test-position-accumulator-snapshot.xsl
+++ b/src/main/resources/xslt/3.0-streamable/streaming-utilities/test-position-accumulator-snapshot.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xmlns:map="http://www.w3.org/2005/xpath-functions/map"
-    xmlns:mf="http://example.com/mf"
+    xmlns:str="https://hiltonroscoe.com/ns/streamatron/v1"
     exclude-result-prefixes="#all"
     expand-text="yes"
     version="3.0">
@@ -14,12 +14,12 @@
     <xsl:mode name="non-streamable" on-no-match="shallow-copy" use-accumulators="position"/>
     
     <xsl:template match="*">
-        <xsl:comment>Position: {mf:position(.)}; path: {mf:path(.)}</xsl:comment>
+        <xsl:comment>Position: {str:position(.)}; path: {str:path(.)}</xsl:comment>
         <xsl:apply-templates select="snapshot()" mode="non-streamable"/>
     </xsl:template>
  
     <xsl:template match="*" mode="non-streamable">
-        <xsl:comment>Position: {mf:position(.)}; path: {mf:path(.)}</xsl:comment>
+        <xsl:comment>Position: {str:position(.)}; path: {str:path(.)}</xsl:comment>
         <xsl:next-match/>
     </xsl:template>
     

--- a/src/main/resources/xslt/3.0-streamable/streaming-utilities/test-position-accumulator.xsl
+++ b/src/main/resources/xslt/3.0-streamable/streaming-utilities/test-position-accumulator.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
     xmlns:map="http://www.w3.org/2005/xpath-functions/map"
-    xmlns:mf="http://example.com/mf"
+    xmlns:str="https://hiltonroscoe.com/ns/streamatron/v1"
     exclude-result-prefixes="#all"
     expand-text="yes"
     version="3.0">
@@ -12,7 +12,7 @@
     <xsl:mode on-no-match="shallow-copy" streamable="yes" use-accumulators="position"/>
     
     <xsl:template match="node()">
-        <xsl:comment>{mf:node-type(.)}: position: {mf:position(.)}; path: {mf:path(.)}</xsl:comment>
+        <xsl:comment>{str:node-type(.)}: position: {str:position(.)}; path: {str:path(.)}</xsl:comment>
         <xsl:next-match/>
     </xsl:template>
     


### PR DESCRIPTION
Add features to 
- support inherited rules (avoiding a copy-of), 
- streaming is disabled by default (if nothing is set for `burst`)
- support `burst="off"`
- support `apply-templates` to `sch:reference` accumulators (aka `saxon:capture` accumulators)

Remaining work includes renaming `@burst` to `@streaming`, reordering of output when reference accumulators are applied, better handling of illegal values in `@burst`, and code cleanup.